### PR TITLE
new GetAwsAccounts method - list all AWS Accounts

### DIFF
--- a/aws_account_test.go
+++ b/aws_account_test.go
@@ -59,6 +59,44 @@ func TestGetAwsAccountOK(t *testing.T) {
 	}
 }
 
+func TestGetAwsAccountsOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "GET" {
+			t.Errorf("Expected ‘GET’ request, got ‘%s’", r.Method)
+		}
+		expectedURL := "/aws_accounts/"
+		if r.URL.EscapedPath() != expectedURL {
+			t.Errorf("Expected request to ‘%s’, got ‘%s’", expectedURL, r.URL.EscapedPath())
+		}
+		body, _ := json.Marshal(defaultAWSAccounts)
+		w.Write(body)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient("apiKey", ts.URL)
+	if err != nil {
+		t.Errorf("NewClient() returned an error: %s", err)
+		return
+	}
+
+	returnedAwsAccounts, err := c.GetAwsAccounts()
+	if err != nil {
+		t.Errorf("NewClient() returned an error: %s", err)
+		return
+	}
+	fmt.Println(returnedAwsAccounts.AwsAccounts)
+	if len(returnedAwsAccounts.AwsAccounts) != 2 {
+		t.Errorf("All accounts have not be retrieved")
+		return
+	}
+	if returnedAwsAccounts.AwsAccounts[0].ID != defaultAWSAccounts.AwsAccounts[0].ID && returnedAwsAccounts.AwsAccounts[0].ID != defaultAWSAccounts.AwsAccounts[1].ID {
+		t.Errorf("Retrieved accounts don't match")
+		return
+	}
+	return
+}
+
 func TestGetAwsAccountDoesntExist(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/aws_account_test.go
+++ b/aws_account_test.go
@@ -14,6 +14,19 @@ var defaultAWSAccount = AwsAccount{
 	Name: "test",
 }
 
+var defaultAWSAccounts = AwsAccounts{
+	AwsAccounts: []AwsAccount{
+		AwsAccount{
+			ID:   1234567890,
+			Name: "test",
+		},
+		AwsAccount{
+			ID:   9876543210,
+			Name: "tset",
+		},
+	},
+}
+
 func TestGetAwsAccountOK(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
New feature :

- method `GetAwsAccounts` lists all enabled AWS accounts in CH

Enhancement :

- new fields added for struct `AwsAccount` 